### PR TITLE
Add setting to show expanded options by default in bookmarking popup

### DIFF
--- a/src/@/components/BookmarkForm.tsx
+++ b/src/@/components/BookmarkForm.tsx
@@ -155,6 +155,14 @@ const BookmarkForm = () => {
   }, [form]);
 
   useEffect(() => {
+    const setExpanded = async () => {
+      const { defaultExpanded } = await getConfig();
+      setOpenOptions(defaultExpanded);
+    };
+    setExpanded();
+  }, []);
+
+  useEffect(() => {
     const syncBookmarks = async () => {
       try {
         const { syncBookmarks, baseUrl, password, usingSSO, username } =

--- a/src/@/components/OptionsForm.tsx
+++ b/src/@/components/OptionsForm.tsx
@@ -46,6 +46,7 @@ const OptionsForm = () => {
       password: '',
       syncBookmarks: false,
       usingSSO: false,
+      defaultExpanded: false,
     },
   });
 
@@ -290,6 +291,28 @@ const OptionsForm = () => {
                 <FormDescription>
                   Enable the use of Single Sign-On instead of regular session
                   (Make sure you're already logged in to Linkwarden).
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={control}
+            name="defaultExpanded"
+            render={({ field }) => (
+              <FormItem>
+                <div className="flex gap-1 items-center">
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                  <FormLabel>Show options in popup</FormLabel>
+                </div>
+
+                <FormDescription>
+                  Show all options in the popup form by default.
                 </FormDescription>
                 <FormMessage />
               </FormItem>

--- a/src/@/lib/config.ts
+++ b/src/@/lib/config.ts
@@ -7,6 +7,7 @@ const DEFAULTS: optionsFormValues = {
   password: '',
   syncBookmarks: false,
   usingSSO: false,
+  defaultExpanded: false,
 };
 
 const CONFIG_KEY = 'lw_config_key';

--- a/src/@/lib/validators/optionsForm.ts
+++ b/src/@/lib/validators/optionsForm.ts
@@ -5,7 +5,8 @@ export const optionsFormSchema = z.object({
   username: z.string().min(1, 'This cannot be empty'),
   password: z.string().min(1, 'This cannot be empty'),
   syncBookmarks: z.boolean().default(false),
-  usingSSO: z.boolean().default(false)
+  usingSSO: z.boolean().default(false),
+  defaultExpanded: z.boolean().default(false)
 });
 
 export type optionsFormValues = z.infer<typeof optionsFormSchema>;


### PR DESCRIPTION
Partially implements #71 with a broad "Show options" setting in the config screen. When enabled, all options are shown by default in the bookmarking popup.