### PR TITLE
Fix keyboard shortcut for Firefox.

### DIFF
--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -26,7 +26,7 @@
   },
   "permissions": ["storage", "activeTab", "tabs", "bookmarks", "contextMenus", "http://*/*", "https://*/*"],
   "commands": {
-    "_execute_action": {
+    "_execute_browser_action": {
       "suggested_key": {
         "default": "Ctrl+Shift+V",
         "mac": "Command+Shift+K"


### PR DESCRIPTION
- (Fixes #76) This commit fixes the issue where the keyboard shortcut (that allows one to simulate a click on the extension icon) was not working in Firefox.
- `manifest.json` has multiple schema versions. The current manifest.json used for Firefox uses v2. The correct key for specifying the desired keyboard shortcut in v2 is `_execute_browser_action`, but the v3 key (`_execute_action`) was being used instead. This commit updates the Firefox manifest.json to use the correct key. (n.b.: the manifest.json for Chrome _is_ using v3). [See the Mozilla `commands` docs for more info](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#special_shortcuts).
- A larger "fix" for this issue that may be arguably more correct is to update the Firefox manifest.json to use the v3 schema (if possible given current extension constraints).