### PR TITLE
Add colleciton nesting display

### DIFF
--- a/src/@/lib/actions/collections.ts
+++ b/src/@/lib/actions/collections.ts
@@ -9,17 +9,54 @@ interface ResponseCollections {
   members: never[]; // Assuming members can be of any type, adjust as necessary
   name: string;
   ownerId: number;
-  parent: null | never; // Assuming parent can be of any type or null, adjust as necessary
+  parent: null | {
+    id: number;
+    name: string;
+  };
   parentId: null | number; // Assuming parentId can be null or a number
   updatedAt: string;
+}
+
+function buildFullPath(
+  collection: ResponseCollections,
+  collectionsMap: Map<number, ResponseCollections>
+): string {
+  const paths: string[] = [collection.name];
+  let currentParent = collection.parent;
+
+  while (currentParent) {
+    paths.unshift(currentParent.name);
+    const parentCollection = collectionsMap.get(currentParent.id);
+    currentParent = parentCollection?.parent || null;
+  }
+
+  return paths.join(' > ');
 }
 
 export async function getCollections(baseUrl: string, apiKey: string) {
   const url = `${baseUrl}/api/v1/collections`;
 
-  return await axios.get<{ response: ResponseCollections[] }>(url, {
+  const response = await axios.get<{ response: ResponseCollections[] }>(url, {
     headers: {
       Authorization: `Bearer ${apiKey}`,
     },
   });
+
+  // Create a map for quick lookups
+  const collectionsMap = new Map(
+    response.data.response.map(collection => [collection.id, collection])
+  );
+
+  // Format the collection names with full parent structure
+  const formattedCollections = response.data.response.map(collection => ({
+    ...collection,
+    name: buildFullPath(collection, collectionsMap)
+  }));
+
+  return {
+    ...response,
+    data: {
+      response: formattedCollections
+    }
+  };
 }


### PR DESCRIPTION
This change changes the colleciton list naming, prints full path to colleciton, instead of colleciton name

Bafore:
![image](https://github.com/user-attachments/assets/3a608bd1-09ec-4b05-bf02-6aa0d36d57d1)

After:
![image](https://github.com/user-attachments/assets/46e11ff6-77aa-44f1-8a93-27d0956eac80)

Motivation - many nested collections can have identically named subcollecitons. And in browser extension, when selection connection there is no way to see parent collection name, thus you cannot choos needed colleciton