### PR TITLE
Show if link is already added

### DIFF
--- a/src/@/lib/actions/links.ts
+++ b/src/@/lib/actions/links.ts
@@ -2,6 +2,7 @@ import captureScreenshot from '../screenshot.ts';
 import { bookmarkFormValues } from '../validators/bookmarkForm.ts';
 import axios from 'axios';
 import { bookmarkMetadata } from '../cache.ts';
+import { getCurrentTabInfo } from '../utils.ts';
 
 export async function postLink(
   baseUrl: string,
@@ -110,4 +111,25 @@ export async function getLinksFetch(
     },
   });
   return await response.json();
+}
+
+export async function checkLinkExists(
+  baseUrl: string,
+  apiKey: string
+): Promise<boolean> {
+  const tabInfo = await getCurrentTabInfo();
+  if (!tabInfo.url) {
+    console.error('No URL found for current tab');
+    return false;
+  }
+  const safeUrl = encodeURIComponent(tabInfo.url);
+  const url = `${baseUrl}/api/v1/links?searchQueryString=${safeUrl}&searchByUrl=true`;
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+  const data = await response.json();
+  const exists = data.response.length > 0;
+  return exists;
 }

--- a/src/pages/Popup/App.tsx
+++ b/src/pages/Popup/App.tsx
@@ -6,10 +6,13 @@ import { useEffect, useState } from 'react';
 import { getConfig, isConfigured } from '../../@/lib/config.ts';
 import Modal from '../../@/components/Modal.tsx';
 import { ModeToggle } from '../../@/components/ModeToggle.tsx';
+import { checkLinkExists } from '../../@/lib/actions/links.ts';
 
 function App() {
   const [isAllConfigured, setIsAllConfigured] = useState<boolean>();
   const [baseUrl, setBaseUrl] = useState<string>();
+  const [alreadyAdded, setAlreadyAdded] = useState<boolean>(false);
+  const [dismissedAlreadyAdded, setDismissedAlreadyAdded] = useState<boolean>(false);
 
   useEffect(() => {
     (async () => {
@@ -17,8 +20,10 @@ function App() {
       const cachedConfig = await getConfig();
       setBaseUrl(cachedConfig.baseUrl);
       setIsAllConfigured(cachedOptions);
+      setAlreadyAdded(await checkLinkExists(cachedConfig.baseUrl, cachedConfig.apiKey));
     })();
   }, []);
+
 
   return (
     <WholeContainer>
@@ -40,7 +45,7 @@ function App() {
                 alt="Linkwarden Logo"
               />
             </a>
-            <h1 className="text-lg">Add Link</h1>
+            { alreadyAdded ? (<h1 className="text-lg">Link already added</h1>) : (<h1 className="text-lg">Add Link</h1>) }
           </div>
           <div className="flex items-center justify-center space-x-2">
             <ModeToggle />
@@ -52,7 +57,7 @@ function App() {
             </p>
           </div>
         </div>
-        <BookmarkForm />
+        { alreadyAdded && !dismissedAlreadyAdded ? (<button onClick={() => setDismissedAlreadyAdded(true)}>Dismiss</button>) : (<BookmarkForm />) }
         <Modal open={!isAllConfigured} />
       </Container>
     </WholeContainer>


### PR DESCRIPTION
When link is not added (identical to before):
![image](https://github.com/user-attachments/assets/f5c32251-b1bc-4740-8cde-458003794276)

When link is already added (new):
![image](https://github.com/user-attachments/assets/6719470c-3ee2-4273-b604-78747314f5e0)

Pressing "dismiss" shows the usual form:
![image](https://github.com/user-attachments/assets/9d68931a-ba90-419c-b693-b98588683065)

I added this so it's clearer to the user if the link has already been saved. I found myself switching back to the web page quite often to check if I had already added it. I added an option to dismiss it in case people still want to add it again for some reason, so they don't have to go to the web page to do so.

The request for the lookup for the URL is done seperately so this functionality not dependant on the server sending all links.

<details>
<summary>Alternative implmentation with caching</summary>

```ts
let linksCache: { [url: string]: boolean } = {};

export async function checkLinkExists(
  baseUrl: string,
  apiKey: string
): Promise<boolean> {
  const tabInfo = await getCurrentTabInfo();
  if (!tabInfo.url) {
    console.error('No URL found for current tab');
    return false;
  }
  if (linksCache.hasOwnProperty(tabInfo.url)) { // hit
    return linksCache[tabInfo.url]; 
  }
  else { // miss
    const safeUrl = encodeURIComponent(tabInfo.url);
    const url = `${baseUrl}/api/v1/links?searchQueryString=${safeUrl}&searchByUrl=true`;
    const response = await fetch(url, {
      headers: {
        Authorization: `Bearer ${apiKey}`,
      },
    });
    const data = await response.json();
    const exists = data.response.length > 0;
    linksCache[tabInfo.url] = exists;
    return exists;
  }
}
```

</details>