### PR TITLE
Add `searchByUrl=true` when checking existing URLs

### DIFF
--- a/src/@/lib/actions/links.ts
+++ b/src/@/lib/actions/links.ts
@@ -124,7 +124,7 @@ export async function checkLinkExists(
   }
 
   const url =
-    `${baseUrl}/api/v1/links?cursor=0&sort=0&searchQueryString=` +
+    `${baseUrl}/api/v1/links?cursor=0&sort=0&searchByUrl=true&searchQueryString=` +
     encodeURIComponent(`${tabInfo.url}`);
 
   console.log('Checking if link exists at:', url);


### PR DESCRIPTION
I believe https://github.com/linkwarden/browser-extension/commit/8b5aeb895af148018c5b798818787d27c499f151 accidentally removed the `searchByUrl=true` parameter when checking existing URLs, resulting the server returning all existing records whether the query matches or not. This patch adds the `searchByUrl=true` parameter back to fix it.