### PR TITLE
Input field in collections select now has autofocus.

### DIFF
--- a/src/@/components/BookmarkForm.tsx
+++ b/src/@/components/BookmarkForm.tsx
@@ -251,6 +251,7 @@ const BookmarkForm = () => {
                           <CommandInput
                             className="min-w-[280px]"
                             placeholder="Search Collection..."
+                            autoFocus={true}
                           />
                           <CommandEmpty>No Collection found.</CommandEmpty>
                           {Array.isArray(collections) && (


### PR DESCRIPTION
When clicking on the collection dropdown/select, the input field is automatically focused. The change was only made for the collection select when "more options" are not shown. The input field is already auto focused with "more options" shown.