### PR TITLE
feat: omnibox live server search + cross-platform build fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "description": "Linkwarden browser extension",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build && cp ./manifest.json dist/manifest.json",
+    "build": "tsc && vite build && node -e \"require('fs').copyFileSync('./manifest.json', './dist/manifest.json')\"",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },
@@ -49,6 +49,7 @@
     "@typescript-eslint/parser": "^6.0.0",
     "@vitejs/plugin-react": "^4.0.3",
     "autoprefixer": "^10.4.14",
+    "baseline-browser-mapping": "^2.10.12",
     "eslint": "^8.45.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",

--- a/src/pages/Background/index.ts
+++ b/src/pages/Background/index.ts
@@ -366,23 +366,51 @@ browser.omnibox.onInputChanged.addListener(
   ) => {
     const configured = await isConfigured();
 
-    if (!configured) {
+    if (!configured || text.length < 2) {
       return;
     }
 
+    // Search local cache (fast, works offline)
     const currentBookmarks = await getBookmarksMetadata();
-
-    const searchedBookmarks = currentBookmarks.filter((bookmark) => {
+    const cachedResults = currentBookmarks.filter((bookmark) => {
       return bookmark.name?.includes(text) || bookmark.url.includes(text);
     });
 
-    const bookmarkSuggestions = searchedBookmarks.map((bookmark) => {
-      return {
-        content: bookmark.url,
-        description: bookmark.name || bookmark.url,
-      };
-    });
-    suggest(bookmarkSuggestions);
+    // Also query the server for full library coverage
+    try {
+      const config = await getConfig();
+      const response = await fetch(
+        `${config.baseUrl}/api/v1/search?sort=0&searchQueryString=${encodeURIComponent(text)}`,
+        { headers: { Authorization: `Bearer ${config.apiKey}` } }
+      );
+
+      if (response.ok) {
+        const data = await response.json();
+        const serverLinks: { url: string; name?: string }[] =
+          data.response ?? [];
+
+        // Merge cache + server results, dedupe by URL
+        const seenUrls = new Set(cachedResults.map((b) => b.url));
+        const combined = [
+          ...cachedResults.map((b) => ({
+            content: b.url,
+            description: b.name || b.url,
+          })),
+          ...serverLinks
+            .filter((l) => l.url && !seenUrls.has(l.url))
+            .map((l) => ({ content: l.url, description: l.name || l.url })),
+        ];
+        suggest(combined);
+        return;
+      }
+    } catch {
+      // Server unreachable — fall through to cache-only results
+    }
+
+    // Fallback: cache-only results
+    suggest(
+      cachedResults.map((b) => ({ content: b.url, description: b.name || b.url }))
+    );
   }
 );
 


### PR DESCRIPTION
## Changes

### Omnibox: live server search
The omnibox previously only searched a local cache, which is empty on fresh installs
and only grows as links are saved through the extension. This meant new users got no
suggestions until they'd built up a cache.

This adds a live call to `/api/v1/search` on each omnibox input (2+ characters),
merging server results with cached results (deduped by URL). If the server is
unreachable it silently falls back to the local cache, preserving existing behavior.

### Cross-platform build script
Replaced the Unix-only `cp` command in the build script with a Node.js
`fs.copyFileSync` call so `npm run build` works correctly on Windows without
a manual copy step.
