### PR TITLE
Fix CSP to allow data: URIs for image upload

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -35,7 +35,7 @@
     "type": "module"
   },
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' http: https:;"
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' http: https: data:;"
   },
   "omnibox": { "keyword": "lk" },
   "commands": {


### PR DESCRIPTION
## Summary

- The "Upload image from browser" feature converts selected images to base64 `data:` URIs, then fetches them to create a blob for upload
- The current CSP `connect-src` directive (`'self' http: https:`) blocks `data:` scheme fetches, causing a `NetworkError when attempting to fetch resource`
- Adding `data:` to `connect-src` resolves this

Closes linkwarden/linkwarden#1613
Related linkwarden/linkwarden#1629

## Fix

One-line change in `manifest.json`: add `data:` to the `connect-src` CSP directive.